### PR TITLE
Fix TypeError with css-split-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {
@@ -94,7 +94,7 @@
     "start": "webpack-dev-server --inline --hot --port 3000 ./playground",
     "babel": "babel ./components --out-dir ./dist/components && babel ./utils --out-dir ./dist/utils",
     "presass": "node-sass ./components --output ./dist/components --importer node_modules/node-sass-module-importer",
-    "sass": "postcss dist/components/**/*.css --replace --use autoprefixer",
+    "sass": "postcss dist/components/**/*.css --replace --use autoprefixer --no-map",
     "dist": "npm run clean && npm run build && npm run sass",
     "build": "cross-env NODE_ENV=dist npm run babel",
     "eslint": "eslint ./components ./playground ./tests --max-warnings 0 --ext jsx --ext js",


### PR DESCRIPTION
Using the `--replace` option along with source maps causes the
`css-split-webpack-plugin` to have problems:

```sh
TypeError: Cannot read property 'toString' of undefined
    at /Users/k/p/kununu/node_modules/css-split-webpack-plugin/dist/index.js:170:73
    at Array.map (native)
    at /Users/k/p/kununu/node_modules/css-split-webpack-plugin/dist/index.js:166:33
    at process._tickCallback (internal/process/next_tick.js:109:7)
```

This can be avoided by disabling the source map with the `--no-map` option.