### PR TITLE
Revert "choice icon added"

### DIFF
--- a/components/Choice/index.jsx
+++ b/components/Choice/index.jsx
@@ -116,7 +116,7 @@ export default class Choice extends Component {
                 disabled={disabled}
                 id={idx}
                 htmlFor={`${name}${item.id}`}
-                className={`${customTheme} ${item.labelClass || ''}`.trim()}>
+                className={customTheme}>
                 {item.label}
               </label>
             </div>

--- a/components/Choice/index.jsx
+++ b/components/Choice/index.jsx
@@ -116,8 +116,7 @@ export default class Choice extends Component {
                 disabled={disabled}
                 id={idx}
                 htmlFor={`${name}${item.id}`}
-                className={customTheme}>
-                {item.icon || null}
+                className={`${customTheme} ${item.labelClass || ''}`.trim()}>
                 {item.label}
               </label>
             </div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "7.7.4",
+  "version": "7.7.3",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "7.8.1",
+  "version": "7.9.0",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/tests/Choice.test.jsx
+++ b/tests/Choice.test.jsx
@@ -5,7 +5,6 @@ import Choice from 'Choice'; // eslint-disable-line import/no-unresolved, import
 
 const options = [
   {
-    icon: <i className="fa fa-thumbs-up" aria-hidden="true" />,
     id: 'opA',
     label: 'Option A',
     value: 'opA'

--- a/tests/Choice.test.jsx
+++ b/tests/Choice.test.jsx
@@ -12,7 +12,6 @@ const options = [
   {
     id: 'opB',
     label: 'Option B',
-    labelClass: 'customMargin',
     value: 'opB'
   },
   {

--- a/tests/__snapshots__/Choice.test.jsx.snap
+++ b/tests/__snapshots__/Choice.test.jsx.snap
@@ -38,7 +38,7 @@ exports[`test Renders Choice with an heading without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -104,7 +104,7 @@ exports[`test Renders Choice with radio buttons without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -170,7 +170,7 @@ exports[`test Renders a Choice with checked from route 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -236,7 +236,7 @@ exports[`test Renders a Choice with custom style 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customThemeClass customMargin"
+        className="customThemeClass"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -302,7 +302,7 @@ exports[`test Renders a Choice with custom style disabled 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customThemeClass customMargin"
+        className="customThemeClass"
         disabled={true}
         htmlFor="testopB"
         id={1}>
@@ -368,7 +368,7 @@ exports[`test Renders a Choice with default checked without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -434,7 +434,7 @@ exports[`test Renders a Choice with no default checked from route if it is not a
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -500,7 +500,7 @@ exports[`test Renders a Choice with no default checked from route if it is the o
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -566,7 +566,7 @@ exports[`test Renders a Choice with no default checked if it's not an option 1`]
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -632,7 +632,7 @@ exports[`test Renders a Choice with optionsPerRow set without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -698,7 +698,7 @@ exports[`test Renders a disabled Choice without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customMargin"
+        className=""
         disabled={true}
         htmlFor="testopB"
         id={1}>

--- a/tests/__snapshots__/Choice.test.jsx.snap
+++ b/tests/__snapshots__/Choice.test.jsx.snap
@@ -24,9 +24,6 @@ exports[`test Renders Choice with an heading without crashing 1`] = `
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -41,7 +38,7 @@ exports[`test Renders Choice with an heading without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -93,9 +90,6 @@ exports[`test Renders Choice with radio buttons without crashing 1`] = `
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -110,7 +104,7 @@ exports[`test Renders Choice with radio buttons without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -162,9 +156,6 @@ exports[`test Renders a Choice with checked from route 1`] = `
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -179,7 +170,7 @@ exports[`test Renders a Choice with checked from route 1`] = `
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -231,9 +222,6 @@ exports[`test Renders a Choice with custom style 1`] = `
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -248,7 +236,7 @@ exports[`test Renders a Choice with custom style 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customThemeClass"
+        className="customThemeClass customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -300,9 +288,6 @@ exports[`test Renders a Choice with custom style disabled 1`] = `
         disabled={true}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -317,7 +302,7 @@ exports[`test Renders a Choice with custom style disabled 1`] = `
         type="radio"
         value="opB" />
       <label
-        className="customThemeClass"
+        className="customThemeClass customMargin"
         disabled={true}
         htmlFor="testopB"
         id={1}>
@@ -369,9 +354,6 @@ exports[`test Renders a Choice with default checked without crashing 1`] = `
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -386,7 +368,7 @@ exports[`test Renders a Choice with default checked without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -438,9 +420,6 @@ exports[`test Renders a Choice with no default checked from route if it is not a
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -455,7 +434,7 @@ exports[`test Renders a Choice with no default checked from route if it is not a
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -507,9 +486,6 @@ exports[`test Renders a Choice with no default checked from route if it is the o
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -524,7 +500,7 @@ exports[`test Renders a Choice with no default checked from route if it is the o
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -576,9 +552,6 @@ exports[`test Renders a Choice with no default checked if it's not an option 1`]
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -593,7 +566,7 @@ exports[`test Renders a Choice with no default checked if it's not an option 1`]
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -645,9 +618,6 @@ exports[`test Renders a Choice with optionsPerRow set without crashing 1`] = `
         disabled={false}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -662,7 +632,7 @@ exports[`test Renders a Choice with optionsPerRow set without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={false}
         htmlFor="testopB"
         id={1}>
@@ -714,9 +684,6 @@ exports[`test Renders a disabled Choice without crashing 1`] = `
         disabled={true}
         htmlFor="testopA"
         id={0}>
-        <i
-          aria-hidden="true"
-          className="fa fa-thumbs-up" />
         Option A
       </label>
     </div>
@@ -731,7 +698,7 @@ exports[`test Renders a disabled Choice without crashing 1`] = `
         type="radio"
         value="opB" />
       <label
-        className=""
+        className="customMargin"
         disabled={true}
         htmlFor="testopB"
         id={1}>


### PR DESCRIPTION
Reverts kununu/nukleus#187

This is being reverted because you can pass elements directly to the choice component which means we do not need an icon prop but rather just pass the icon directly in with the label.