### PR TITLE
Fix firefox bug

### DIFF
--- a/components/Stars/index.scss
+++ b/components/Stars/index.scss
@@ -87,6 +87,7 @@
 
   @supports (display: flex) {
     height: auto;
+    max-height: 100%;
   }
 
   @media (max-width: $screen-xs-max) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "7.8.0",
+  "version": "7.9.1",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {


### PR DESCRIPTION
Fixes firefox not supporting svg height: auto for the star component.
https://stackoverflow.com/questions/7570917/svg-height-incorrectly-calculated-in-webkit-browsers