### PR TITLE
Fix so stars don’t collapse in firefox

### DIFF
--- a/components/Stars/index.scss
+++ b/components/Stars/index.scss
@@ -11,10 +11,6 @@
   display: table;
   table-layout: fixed;
 
-  @supports (display: flex) {
-    display: flex;
-  }
-
   label {
     margin: 0;
     line-height: 0;
@@ -27,19 +23,11 @@
 
 .starsRow {
   display: table-row;
-
-  @supports (display: flex) {
-    display: flex;
-  }
 }
 
 .starsGroup {
   display: table-cell;
   padding: 0 10px;
-
-  @supports (display: flex) {
-    display: flex;
-  }
 }
 
 .hideStarGroup {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {


### PR DESCRIPTION
- When I remove display flex it stops the collapsing