### PR TITLE
Show "not found" on autocomplete focus

### DIFF
--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -75,6 +75,7 @@ export default class Autocomplete extends React.Component {
   };
 
   state = {
+    hasInitialized: false,
     showError: false,
     showNoSuggestionsText: false,
     suggestions: this.props.data.items || [],
@@ -92,6 +93,7 @@ export default class Autocomplete extends React.Component {
     if (JSON.stringify(nextProps.data.items) !== JSON.stringify(this.props.data.items)) {
       this.setState({suggestions: nextProps.data.items});
     }
+
     if (nextProps.error) this.showError();
     if (!this.needsUpdate(nextProps)) return;
     this.updateValue(this.props.query[this.props.name] || nextProps.value || '');
@@ -99,7 +101,6 @@ export default class Autocomplete extends React.Component {
 
   onChange = (event, {newValue}) => {
     this.setState({
-      showNoSuggestionsText: true,
       value: newValue
     });
     this.props.onChange(event);
@@ -116,6 +117,7 @@ export default class Autocomplete extends React.Component {
 
   onBlur = ev => {
     this.hideNoSuggestionsText();
+    this.setState({hasInitialized: false});
     this.props.onBlur(ev);
   }
 
@@ -130,9 +132,7 @@ export default class Autocomplete extends React.Component {
   };
 
   onSuggestionSelected = (e, {method, suggestion}) => {
-    this.setState({
-      showNoSuggestionsText: false
-    });
+    this.hideNoSuggestionsText();
 
     if (method === 'enter' && !this.props.submitOnEnter) {
       e.preventDefault();
@@ -148,6 +148,8 @@ export default class Autocomplete extends React.Component {
     const inputLength = inputValue.length;
 
     if (inputValue) {
+      this.setState({hasInitialized: true});
+
       if (this.props.onGetSuggestions) {
         this.props.onGetSuggestions(inputValue);
         return this.props.data.items;
@@ -262,6 +264,7 @@ export default class Autocomplete extends React.Component {
     } = this.props;
 
     const {
+      hasInitialized,
       showNoSuggestionsText,
       suggestions,
       value
@@ -325,7 +328,7 @@ export default class Autocomplete extends React.Component {
             </span>
           }
 
-          {!isFetching && !suggestions.length && value && showNoSuggestionsText ?
+          {hasInitialized && showNoSuggestionsText && !isFetching && !suggestions.length && value ?
             <div className={styles.suggestionsContainer}>
               <ul>
                 <li className={styles.suggestion}>

--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -107,6 +107,9 @@ export default class Autocomplete extends React.Component {
   }
 
   onFocus = ev => {
+    this.setState({
+      showNoSuggestionsText: true
+    });
     this.scrollToElement();
     this.props.onFocus(ev);
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "8.1.4",
+  "version": "8.2.0",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/playground/app.jsx
+++ b/playground/app.jsx
@@ -158,7 +158,7 @@ const App = ({location: {pathname, query}}) => (
         <br />
 
         <div className="row">
-          <div className="col-xs-12 col-sm-5 col-md-2">
+          <div className="col-xs-12 col-sm-5 col-md-4">
             <Stars
               value={3}
               name="test"
@@ -249,7 +249,6 @@ const App = ({location: {pathname, query}}) => (
         <div className="row">
           <div className="col-md-8">
             <Autocomplete
-              autoFocus
               data={{
                 items: [
                   {item: 'meow', itemInfo: 'hard'},

--- a/tests/Autocomplete.test.jsx
+++ b/tests/Autocomplete.test.jsx
@@ -68,6 +68,7 @@ test('Renders Autocomplete with Error without crashing', () => {
 
 test('Renders no suggestions container', done => {
   const component = mount(staticAutocomplete);
+  component.find('input').simulate('focus');
   component.find('input').simulate('change', {target: {value: 'z'}});
 
   // waiting for debounce


### PR DESCRIPTION
- If you focus on autocomplete and there is text in the field it should show the "not found" box.