### PR TITLE
bug fix, on devices with autoFocus enabled

### DIFF
--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -15,8 +15,8 @@ import sharedStyles, {
   controlNote,
   formControl,
   formControlError,
-  hidden,
   formGroup,
+  hidden,
   srOnly
 } from '../index.scss';
 
@@ -89,6 +89,10 @@ export default class Autocomplete extends React.Component {
     if (this.props.error !== null) this.showError();
   }
 
+  componentDidMount () {
+    if (this.scrollRequestedOnStartUp) this.scrollToElement();
+  }
+
   componentWillReceiveProps (nextProps) {
     if (JSON.stringify(nextProps.data.items) !== JSON.stringify(this.props.data.items)) {
       this.setState({suggestions: nextProps.data.items});
@@ -111,7 +115,11 @@ export default class Autocomplete extends React.Component {
     this.setState({
       showNoSuggestionsText: true
     });
-    this.scrollToElement();
+    if (this.node) {
+      this.scrollToElement();
+    } else {
+      this.scrollRequestedOnStartUp = true;
+    }
     this.props.onFocus(ev);
   }
 
@@ -168,6 +176,8 @@ export default class Autocomplete extends React.Component {
       suggestions: this.getSuggestions(value)
     });
   }
+
+  scrollRequestedOnStartUp = false;
 
   debouncedLoadSuggestions = debounce(this.loadSuggestions, this.props.debounceRate);
 

--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -89,10 +89,6 @@ export default class Autocomplete extends React.Component {
     if (this.props.error !== null) this.showError();
   }
 
-  componentDidMount () {
-    if (this.scrollRequestedOnStartUp) this.scrollToElement();
-  }
-
   componentWillReceiveProps (nextProps) {
     if (JSON.stringify(nextProps.data.items) !== JSON.stringify(this.props.data.items)) {
       this.setState({suggestions: nextProps.data.items});
@@ -115,11 +111,11 @@ export default class Autocomplete extends React.Component {
     this.setState({
       showNoSuggestionsText: true
     });
+
     if (this.node) {
       this.scrollToElement();
-    } else {
-      this.scrollRequestedOnStartUp = true;
     }
+
     this.props.onFocus(ev);
   }
 

--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -112,6 +112,8 @@ export default class Autocomplete extends React.Component {
       showNoSuggestionsText: true
     });
 
+    // Prevents autoscroll if element is not
+    // in the DOM
     if (this.node) {
       this.scrollToElement();
     }
@@ -172,8 +174,6 @@ export default class Autocomplete extends React.Component {
       suggestions: this.getSuggestions(value)
     });
   }
-
-  scrollRequestedOnStartUp = false;
 
   debouncedLoadSuggestions = debounce(this.loadSuggestions, this.props.debounceRate);
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {


### PR DESCRIPTION
**MINOR BUG FIX**
Currently if you have autoFocus and the scrollTo you will see an error in the console due to the component not being in the dom before it tries to scroll.