### PR TITLE
Do not render suggestion info if its content is not provided

### DIFF
--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -253,7 +253,13 @@ export default class Autocomplete extends React.Component {
     return classNames.join(' ');
   }
 
-  renderSuggestion = suggestion => <span>{suggestion.item}<span className={styles.suggestionInfo}>&nbsp;({suggestion.itemInfo})</span></span>;
+  renderSuggestion = suggestion =>
+    (<span>
+      {suggestion.item}
+      {(suggestion.itemInfo !== undefined && suggestion.itemInfo !== null && suggestion.itemInfo.length > 0) &&
+        <span className={styles.suggestionInfo}>&nbsp;({suggestion.itemInfo})</span>
+      }
+    </span>);
 
   render () {
     const {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/playground/app.jsx
+++ b/playground/app.jsx
@@ -230,7 +230,8 @@ const App = ({location: {pathname, query}}) => (
                 data={{
                   items: [
                     {item: 'meow', itemInfo: 'hard'},
-                    {item: 'meowing', itemInfo: 'harder'}
+                    {item: 'meowing', itemInfo: 'harder'},
+                    {item: 'meeeow'}
                   ]
                 }}
                 scrollTo

--- a/tests/Autocomplete.test.jsx
+++ b/tests/Autocomplete.test.jsx
@@ -16,7 +16,13 @@ const staticAutocomplete = (
         {item: 'alpha', itemInfo: 'Vienna'},
         {item: 'IBM', itemInfo: 'US'},
         {item: 'kununu', itemInfo: 'Vienna'},
-        {item: 'kununu', itemInfo: 'US'}
+        {item: 'kununu', itemInfo: 'US'},
+        {item: 'kununu'},
+        {item: 'kununu', itemInfo: null},
+        {item: 'kununu', itemInfo: ''},
+        {item: 'kununu', itemInfo: 0},
+        {item: 'kununu', itemInfo: false},
+        {item: 'kununu', itemInfo: true}
       ]
     }}
     value="test"
@@ -128,11 +134,11 @@ test('Fetches suggestions on change', done => {
 test('Fetches Value only when debounce is over', done => {
   const component = mount(staticAutocomplete);
   component.find('input').simulate('change', {target: {value: 'kunu'}});
-  expect(component.state().suggestions.length).toEqual(5);
+  expect(component.state().suggestions.length).toEqual(11);
 
   // waiting for debounce
   waitingForDebounce(() => {
-    expect(component.state().suggestions.length).toEqual(2);
+    expect(component.state().suggestions.length).toEqual(8);
     done();
   });
 });

--- a/tests/Autocomplete.test.jsx
+++ b/tests/Autocomplete.test.jsx
@@ -17,7 +17,7 @@ const staticAutocomplete = (
         {item: 'IBM', itemInfo: 'US'},
         {item: 'kununu', itemInfo: 'Vienna'},
         {item: 'kununu', itemInfo: 'US'},
-        {item: 'kununu'},
+        {item: 'kununu'}
       ]
     }}
     value="test"

--- a/tests/Autocomplete.test.jsx
+++ b/tests/Autocomplete.test.jsx
@@ -18,11 +18,6 @@ const staticAutocomplete = (
         {item: 'kununu', itemInfo: 'Vienna'},
         {item: 'kununu', itemInfo: 'US'},
         {item: 'kununu'},
-        {item: 'kununu', itemInfo: null},
-        {item: 'kununu', itemInfo: ''},
-        {item: 'kununu', itemInfo: 0},
-        {item: 'kununu', itemInfo: false},
-        {item: 'kununu', itemInfo: true}
       ]
     }}
     value="test"
@@ -134,11 +129,11 @@ test('Fetches suggestions on change', done => {
 test('Fetches Value only when debounce is over', done => {
   const component = mount(staticAutocomplete);
   component.find('input').simulate('change', {target: {value: 'kunu'}});
-  expect(component.state().suggestions.length).toEqual(11);
+  expect(component.state().suggestions.length).toEqual(6);
 
   // waiting for debounce
   waitingForDebounce(() => {
-    expect(component.state().suggestions.length).toEqual(8);
+    expect(component.state().suggestions.length).toEqual(3);
     done();
   });
 });

--- a/tests/__snapshots__/Autocomplete.test.jsx.snap
+++ b/tests/__snapshots__/Autocomplete.test.jsx.snap
@@ -27,26 +27,6 @@ exports[`test Hides no suggestions on blur 1`] = `
         Object {
           "item": "kununu",
         },
-        Object {
-          "item": "kununu",
-          "itemInfo": null,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": "",
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": 0,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": false,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": true,
-        },
       ],
     }
   }
@@ -317,26 +297,6 @@ exports[`test Renders no suggestions container 1`] = `
         Object {
           "item": "kununu",
         },
-        Object {
-          "item": "kununu",
-          "itemInfo": null,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": "",
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": 0,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": false,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": true,
-        },
       ],
     }
   }
@@ -513,26 +473,6 @@ exports[`test Renders suggestions container 1`] = `
         },
         Object {
           "item": "kununu",
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": null,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": "",
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": 0,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": false,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": true,
         },
       ],
     }
@@ -849,26 +789,6 @@ exports[`test Updates value on selection 1`] = `
         },
         Object {
           "item": "kununu",
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": null,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": "",
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": 0,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": false,
-        },
-        Object {
-          "item": "kununu",
-          "itemInfo": true,
         },
       ],
     }

--- a/tests/__snapshots__/Autocomplete.test.jsx.snap
+++ b/tests/__snapshots__/Autocomplete.test.jsx.snap
@@ -24,6 +24,29 @@ exports[`test Hides no suggestions on blur 1`] = `
           "item": "kununu",
           "itemInfo": "US",
         },
+        Object {
+          "item": "kununu",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": null,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": "",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": 0,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": false,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": true,
+        },
       ],
     }
   }
@@ -291,6 +314,29 @@ exports[`test Renders no suggestions container 1`] = `
           "item": "kununu",
           "itemInfo": "US",
         },
+        Object {
+          "item": "kununu",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": null,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": "",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": 0,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": false,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": true,
+        },
       ],
     }
   }
@@ -464,6 +510,29 @@ exports[`test Renders suggestions container 1`] = `
         Object {
           "item": "kununu",
           "itemInfo": "US",
+        },
+        Object {
+          "item": "kununu",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": null,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": "",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": 0,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": false,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": true,
         },
       ],
     }
@@ -777,6 +846,29 @@ exports[`test Updates value on selection 1`] = `
         Object {
           "item": "kununu",
           "itemInfo": "US",
+        },
+        Object {
+          "item": "kununu",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": null,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": "",
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": 0,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": false,
+        },
+        Object {
+          "item": "kununu",
+          "itemInfo": true,
         },
       ],
     }

--- a/tests/__snapshots__/Modal.test.jsx.snap
+++ b/tests/__snapshots__/Modal.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`test Renders Modal without crashing 1`] = `
     onEnter={[Function]}
     onExit={[Function]}
     open={true}
+    scrollDisabled={true}
     titleId="nukleus-modal-title"
     titleText="Modal"
     underlayClass="underlay underlayHasEntered"


### PR DESCRIPTION
Currently a suggestion is rendered like:

```
 <span>{suggestion.item}<span className={styles.suggestionInfo}>&nbsp;({suggestion.itemInfo})</span></span>;
```

Which means that if the `info`a suggestion is not provided `empty parenthises()` are rendered like:

![empty](https://user-images.githubusercontent.com/22587229/32046978-7dc6069e-ba3c-11e7-8a69-94c5e15c6b6d.png)

This PR changes this behavior by only render the `info` when has content, ie: its not `undefined`, `null`, `''`, `false`, `true`
