### PR TITLE
Allow disabled options on Choice Component

### DIFF
--- a/components/Choice/index.jsx
+++ b/components/Choice/index.jsx
@@ -83,9 +83,9 @@ export default class Choice extends React.Component {
     }
   }
 
-  onChange = e => {
+  onChange = (option, e) => {
     const value = e.target.value;
-    if (this.props.disabled || value === this.state.checked) return;
+    if (this.isOptionDisabled(option) || value === this.state.checked) return;
 
     this.props.onChange(e);
     this.setState({
@@ -93,9 +93,10 @@ export default class Choice extends React.Component {
     });
   };
 
-  onClick = e => {
+  onClick = (option, e) => {
+    if (this.isOptionDisabled(option)) return;
+
     const value = e.target.value;
-    if (this.props.disabled) return;
 
     this.props.onClick(e);
     // As long as the component is not required and the component is deselected set to null.
@@ -118,10 +119,14 @@ export default class Choice extends React.Component {
     return this.state.showError && this.props.error;
   }
 
+  isOptionDisabled (option) {
+    const disabled = this.props.disabled;
+    return disabled || (typeof (option.disabled) === 'boolean' ? option.disabled : disabled);
+  }
+
   render () {
     const {
       customTheme,
-      disabled,
       error,
       errorSubInfo,
       heading,
@@ -161,13 +166,13 @@ export default class Choice extends React.Component {
                 name={name}
                 checked={checked === item.value}
                 onBlur={onBlur}
-                onChange={this.onChange}
+                onChange={e => this.onChange(item, e)}
                 onFocus={onFocus}
-                onClick={this.onClick}
+                onClick={e => this.onClick(item, e)}
                 ref={reference}
                 required={isRequired} />
               <label
-                disabled={disabled}
+                disabled={this.isOptionDisabled(item)}
                 id={idx}
                 htmlFor={`${name}${item.id}`}
                 className={customTheme}>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/playground/app.jsx
+++ b/playground/app.jsx
@@ -804,6 +804,36 @@ const App = ({location: {pathname, query}}) => (
         <div className="row">
           <div className="col-md-10">
             <Choice
+              checked="option-a"
+              name="custom-option-disabled"
+              onChange={() => {}}
+              customTheme={styles.customThemeChoice}
+              options={[
+                {
+                  id: 'option-a',
+                  label: 'Option A',
+                  value: 'option-a'
+                },
+                {
+                  id: 'option-b',
+                  label: 'Option B Disabled',
+                  value: 'option-b',
+                  disabled: true,
+                },
+                {
+                  id: 'option-c',
+                  label: 'Option C',
+                  value: 'option-c'
+                }
+              ]} />
+          </div>
+        </div>
+
+        <br />
+
+        <div className="row">
+          <div className="col-md-10">
+            <Choice
               heading="Choice with multiple rows"
               name="option-3-6"
               onChange={() => {}}

--- a/tests/Choice.test.jsx
+++ b/tests/Choice.test.jsx
@@ -62,8 +62,8 @@ test('Renders a disabled Choice without crashing', () => {
 test('Renders a Choice with a disabled option without crashing', () => {
   const newOptions = options.concat([
     {
-      id: 'opD',
       disabled: true,
+      id: 'opD',
       label: 'Option D',
       value: 'opD'
     }
@@ -241,8 +241,8 @@ test('Does not fire onChange function when clicked if Choice is disabled', () =>
 test('Does not fire onChange function when clicked option is disabled', () => {
   const newOptions = options.concat([
     {
-      id: 'opD',
       disabled: true,
+      id: 'opD',
       label: 'Option D',
       value: 'opD'
     }

--- a/tests/Choice.test.jsx
+++ b/tests/Choice.test.jsx
@@ -60,12 +60,12 @@ test('Renders a disabled Choice without crashing', () => {
 });
 
 test('Renders a Choice with a disabled option without crashing', () => {
-  let newOptions = options.concat([
+  const newOptions = options.concat([
     {
       id: 'opD',
+      disabled: true,
       label: 'Option D',
-      value: 'opD',
-      disabled: true
+      value: 'opD'
     }
   ]);
 
@@ -239,12 +239,12 @@ test('Does not fire onChange function when clicked if Choice is disabled', () =>
 });
 
 test('Does not fire onChange function when clicked option is disabled', () => {
-  let newOptions = options.concat([
+  const newOptions = options.concat([
     {
       id: 'opD',
+      disabled: true,
       label: 'Option D',
-      value: 'opD',
-      disabled: true
+      value: 'opD'
     }
   ]);
 

--- a/tests/Choice.test.jsx
+++ b/tests/Choice.test.jsx
@@ -59,6 +59,27 @@ test('Renders a disabled Choice without crashing', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Renders a Choice with a disabled option without crashing', () => {
+  let newOptions = options.concat([
+    {
+      id: 'opD',
+      label: 'Option D',
+      value: 'opD',
+      disabled: true
+    }
+  ]);
+
+  const component = renderer.create(
+    <Choice
+      name="test"
+      options={newOptions}
+      onChange={() => {}} />
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Renders a Choice with default checked without crashing', () => {
   const component = renderer.create(
     <Choice
@@ -214,6 +235,28 @@ test('Does not fire onChange function when clicked if Choice is disabled', () =>
   );
 
   component.find('#testopA').simulate('change');
+  expect(spyFunc).not.toHaveBeenCalled();
+});
+
+test('Does not fire onChange function when clicked option is disabled', () => {
+  let newOptions = options.concat([
+    {
+      id: 'opD',
+      label: 'Option D',
+      value: 'opD',
+      disabled: true
+    }
+  ]);
+
+  const spyFunc = jest.fn();
+  const component = mount(
+    <Choice
+      name="test"
+      options={newOptions}
+      onChange={spyFunc} />
+  );
+
+  component.find('#testopD').simulate('change');
   expect(spyFunc).not.toHaveBeenCalled();
 });
 

--- a/tests/__snapshots__/Choice.test.jsx.snap
+++ b/tests/__snapshots__/Choice.test.jsx.snap
@@ -151,6 +151,102 @@ exports[`test Renders Choice with radio buttons without crashing 1`] = `
 </div>
 `;
 
+exports[`test Renders a Choice with a disabled option without crashing 1`] = `
+<div
+  className="formGroup">
+  
+  
+  <div
+    className="radioContainer flexible"
+    data-options-per-row={null}>
+    <div
+      className="radioButton">
+      <input
+        checked={false}
+        id="testopA"
+        name="test"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        required={false}
+        type="radio"
+        value="opA" />
+      <label
+        className=""
+        disabled={false}
+        htmlFor="testopA"
+        id={0}>
+        Option A
+      </label>
+    </div>
+    <div
+      className="radioButton">
+      <input
+        checked={false}
+        id="testopB"
+        name="test"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        required={false}
+        type="radio"
+        value="opB" />
+      <label
+        className=""
+        disabled={false}
+        htmlFor="testopB"
+        id={1}>
+        Option B
+      </label>
+    </div>
+    <div
+      className="radioButton">
+      <input
+        checked={false}
+        id="testopC"
+        name="test"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        required={false}
+        type="radio"
+        value="opC" />
+      <label
+        className=""
+        disabled={false}
+        htmlFor="testopC"
+        id={2}>
+        Option C
+      </label>
+    </div>
+    <div
+      className="radioButton">
+      <input
+        checked={false}
+        id="testopD"
+        name="test"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        required={false}
+        type="radio"
+        value="opD" />
+      <label
+        className=""
+        disabled={true}
+        htmlFor="testopD"
+        id={3}>
+        Option D
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`test Renders a Choice with checked from route 1`] = `
 <div
   className="formGroup">


### PR DESCRIPTION
Currently the Choice Component allows to disable the whole choice component options.

![disabled_choice](https://user-images.githubusercontent.com/22587229/32106064-8a0fc52a-bb22-11e7-943e-64c68c55de48.png)

This PR aims to allow to disable a single option.

![single_option_disabled](https://user-images.githubusercontent.com/22587229/32106115-abd645a8-bb22-11e7-90bb-b0329e21d5da.png)

How its implemented:

You can provide a `disabled` key for the item.

https://github.com/kununu/nukleus/blob/8a049b399159c461e2053d3fbe9c038fcb502b6b/components/Choice/index.jsx#L122

![logic](https://user-images.githubusercontent.com/22587229/32106181-d457dc9e-bb22-11e7-8ee1-15fc624e8707.png)

