### PR TITLE
Fix autocomplete suggestions list - IE bug

### DIFF
--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -261,6 +261,18 @@ export default class Autocomplete extends React.Component {
       }
     </span>);
 
+  renderSuggestionsContainer = ({containerProps, children}) => {
+    if (this.state.suggestions.length) {
+      return (
+        <div {...containerProps} className={styles.suggestionsContainer}>
+          {children}
+        </div>
+      );
+    }
+
+    return null;
+  }
+
   render () {
     const {
       autoFocus,
@@ -332,6 +344,7 @@ export default class Autocomplete extends React.Component {
             onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
             onSuggestionsClearRequested={this.onSuggestionsClearRequested}
             renderSuggestion={this.renderSuggestion}
+            renderSuggestionsContainer={this.renderSuggestionsContainer}
             suggestions={suggestions}
             theme={styles} />
 

--- a/components/Autocomplete/index.scss
+++ b/components/Autocomplete/index.scss
@@ -25,7 +25,7 @@
   width: 100%;
   margin-top: 1px;
   background-color: $white;
-  height: auto;
+  max-height: 300px;
   overflow: auto;
   position: absolute;
   top: 100%;

--- a/components/Autocomplete/index.scss
+++ b/components/Autocomplete/index.scss
@@ -25,7 +25,7 @@
   width: 100%;
   margin-top: 1px;
   background-color: $white;
-  max-height: 300px;
+  height: auto;
   overflow: auto;
   position: absolute;
   top: 100%;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/tests/__snapshots__/Autocomplete.test.jsx.snap
+++ b/tests/__snapshots__/Autocomplete.test.jsx.snap
@@ -155,9 +155,6 @@ exports[`test Hides no suggestions on blur 1`] = `
               style={Object {}}
               type="text"
               value="z" />
-            <div
-              id="react-autowhatever-1"
-              style={Object {}} />
           </div>
         </Autowhatever>
       </Autosuggest>
@@ -205,6 +202,7 @@ exports[`test Renders Autocomplete with Error without crashing 1`] = `
         type="text"
         value="test" />
       <div
+        className="suggestionsContainer"
         id="react-autowhatever-1"
         style={Object {}} />
     </div>
@@ -260,6 +258,7 @@ exports[`test Renders Autocomplete without crashing 1`] = `
         type="text"
         value="test" />
       <div
+        className="suggestionsContainer"
         id="react-autowhatever-1"
         style={Object {}} />
     </div>
@@ -425,9 +424,6 @@ exports[`test Renders no suggestions container 1`] = `
               style={Object {}}
               type="text"
               value="z" />
-            <div
-              id="react-autowhatever-1"
-              style={Object {}} />
           </div>
         </Autowhatever>
       </Autosuggest>
@@ -625,6 +621,7 @@ exports[`test Renders suggestions container 1`] = `
               type="text"
               value="a" />
             <div
+              className="suggestionsContainer"
               id="react-autowhatever-1"
               style={Object {}}>
               <ItemsList
@@ -918,9 +915,6 @@ exports[`test Updates value on selection 1`] = `
               style={Object {}}
               type="text"
               value="apple" />
-            <div
-              id="react-autowhatever-1"
-              style={Object {}} />
           </div>
         </Autowhatever>
       </Autosuggest>


### PR DESCRIPTION
- Bug fix: The empty suggestions box fills the entire height after selecting a suggestion out of a large list. Seems that IE does not like max-height: 300px. To prevent this I do not render the suggestions box if there are no suggestions.