### PR TITLE
Fix label font weight

### DIFF
--- a/components/index.scss
+++ b/components/index.scss
@@ -264,5 +264,8 @@
   label {
     margin: 0 10px 0 0;
     width: auto;
+    color: $gray-base-90;
+    font-size: $font-size-base;
+    font-weight: $font-weight-semibold;
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {


### PR DESCRIPTION
This fixes the styling for labels, that are not generated by nukleus components but get passed as react children. 