### PR TITLE
Fix infobox outside window border with scrollbar

### DIFF
--- a/components/InfoBox/index.jsx
+++ b/components/InfoBox/index.jsx
@@ -36,7 +36,7 @@ export default class InfoBox extends React.Component {
 
   get translatedXByScreenEdge () {
     // Check if rect is outside right window border
-    if (this.positionRight > window.innerWidth) return (this.positionRight - window.innerWidth) * -1;
+    if (this.positionRight > window.innerWidth) return (((this.positionRight - window.innerWidth) * -1) - (window.innerWidth - document.body.clientWidth));
 
     // Check if rect is outside left window border
     if (this.positionLeft < 0) return this.positionLeft * -1;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "12.0.2",
+  "version": "12.0.3",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {


### PR DESCRIPTION
When the window has a scrollbar, the scroll bar width needs the be taken in consideration when translating the infobox.