### PR TITLE
Add unique container identifiers

### DIFF
--- a/components/Autocomplete/index.jsx
+++ b/components/Autocomplete/index.jsx
@@ -353,7 +353,8 @@ export default class Autocomplete extends React.Component {
     return (
       <div
         ref={node => this.node = node}
-        className={this.containerClassNames}>
+        className={this.containerClassNames}
+        id={`${name}-container`}>
 
         {requiredLabel &&
           <span className={`${controlNote} ${controlLabelRequired}`}>

--- a/components/Choice/index.jsx
+++ b/components/Choice/index.jsx
@@ -189,7 +189,7 @@ export default class Choice extends React.Component {
     } = this.state;
 
     return (
-      <div className={formGroup}>
+      <div className={formGroup} id={`${name}-container`}>
 
         {requiredLabel &&
           <span className={`${controlNote} ${controlLabelRequired}`}>

--- a/components/Combobox/index.jsx
+++ b/components/Combobox/index.jsx
@@ -162,7 +162,7 @@ export default class ComboboxComponent extends React.Component {
     } = this.props;
 
     return (
-      <div className={`${formGroup} ${styles[inputStyles]} ${requiredLabel ? styles.paddingTop : ''}`}>
+      <div className={`${formGroup} ${styles[inputStyles]} ${requiredLabel ? styles.paddingTop : ''}`} id={`${name}-container`}>
         {requiredLabel &&
           <span className={`${controlNote} ${controlLabelRequired}`}>
             {requiredLabel}

--- a/components/DatePicker/index.jsx
+++ b/components/DatePicker/index.jsx
@@ -156,7 +156,7 @@ export default class DatePickerComponent extends React.Component {
     } = this.props;
 
     return (
-      <div className={`${formGroup} ${styles[inputStyle]} ${styles.datePickerContainer} ${requiredLabel ? styles.paddingTop : ''}`}>
+      <div className={`${formGroup} ${styles[inputStyle]} ${styles.datePickerContainer} ${requiredLabel ? styles.paddingTop : ''}`} id={`${name}-container`}>
         {requiredLabel &&
           <span className={`${controlNote} ${controlLabelRequired}`}>
             {requiredLabel}

--- a/components/MultipleChoice/index.jsx
+++ b/components/MultipleChoice/index.jsx
@@ -165,9 +165,10 @@ export default class MultipleChoice extends React.Component {
 
   render () {
     const {choices} = this.state;
+    const {name} = this.props;
 
     return (
-      <div className={this.containerClassNames} id={`${this.props.name}-container`}>
+      <div className={this.containerClassNames} id={`${name}-container`}>
         {this.props.requiredLabel &&
           <span className={`${controlNote} ${controlLabelRequired}`}>
             {this.props.requiredLabel}

--- a/components/MultipleChoice/index.jsx
+++ b/components/MultipleChoice/index.jsx
@@ -167,7 +167,7 @@ export default class MultipleChoice extends React.Component {
     const {choices} = this.state;
 
     return (
-      <div className={this.containerClassNames}>
+      <div className={this.containerClassNames} id={`${this.props.name}-container`}>
         {this.props.requiredLabel &&
           <span className={`${controlNote} ${controlLabelRequired}`}>
             {this.props.requiredLabel}

--- a/components/Select/index.jsx
+++ b/components/Select/index.jsx
@@ -223,7 +223,7 @@ export default class Select extends React.Component {
     }
 
     return (
-      <div className={this.containerClassNames}>
+      <div className={this.containerClassNames} id={`${name}-container`}>
 
         {requiredLabel &&
           <span className={`${controlNote} ${controlLabelRequired}`}>

--- a/components/Stars/index.jsx
+++ b/components/Stars/index.jsx
@@ -125,7 +125,7 @@ export default class Stars extends React.Component {
     const {color, value} = this.state;
 
     return (
-      <div className={`${styles.starsContainer} ${!selectable && styles.staticStars}`}>
+      <div className={`${styles.starsContainer} ${!selectable && styles.staticStars}`} id={`${name}-container`}>
         <div className={styles.starsRow}>
           {[...Array(totalStars + 1)].map((star, key) =>
             (

--- a/components/TextField/index.jsx
+++ b/components/TextField/index.jsx
@@ -360,7 +360,7 @@ export default class TextField extends React.Component {
     const {highlightedContent} = this.state;
 
     return (
-      <div className={this.containerClassNames}>
+      <div className={this.containerClassNames} id={`${name}-container`}>
         {this.state.highlightContent}
         <InfoLabel
           requiredLabel={requiredLabel}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "12.0.5",
+  "version": "12.1.0",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "12.0.4",
+  "version": "12.0.5",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/tests/__snapshots__/Autocomplete.test.jsx.snap
+++ b/tests/__snapshots__/Autocomplete.test.jsx.snap
@@ -59,6 +59,7 @@ exports[`Hides no suggestions on blur 1`] = `
 >
   <div
     className="formGroup inline paddingTop"
+    id="autocomplete-container"
   >
     <span
       className="controlNote controlLabelRequired"
@@ -142,17 +143,14 @@ exports[`Hides no suggestions on blur 1`] = `
           theme={Object {}}
         >
           <div
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-owns="react-autowhatever-autocompletes"
             key="react-autowhatever-autocompletes-container"
-            role="combobox"
             style={Object {}}
           >
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-controls="react-autowhatever-autocompletes"
+              aria-expanded={false}
+              aria-owns="react-autowhatever-autocompletes"
               autoComplete="off"
               autoFocus={false}
               className="formControl "
@@ -166,6 +164,7 @@ exports[`Hides no suggestions on blur 1`] = `
               onKeyDown={[Function]}
               placeholder="Type something..."
               required={true}
+              role="combobox"
               style={Object {}}
               type="text"
               value="z"
@@ -181,6 +180,7 @@ exports[`Hides no suggestions on blur 1`] = `
 exports[`Renders Autocomplete with Error without crashing 1`] = `
 <div
   className="formGroup inline paddingTop"
+  id="autocomplete-container"
 >
   <span
     className="controlNote controlLabelRequired"
@@ -197,16 +197,13 @@ exports[`Renders Autocomplete with Error without crashing 1`] = `
     className="autoCompleteContainer"
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="listbox"
-      aria-owns="react-autowhatever-autocompletes"
-      role="combobox"
       style={Object {}}
     >
       <input
         aria-activedescendant={null}
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-autocompletes"
+        aria-expanded={false}
+        aria-owns="react-autowhatever-autocompletes"
         autoComplete="off"
         autoFocus={false}
         className="formControl formControlError"
@@ -219,6 +216,7 @@ exports[`Renders Autocomplete with Error without crashing 1`] = `
         onKeyDown={[Function]}
         placeholder="Type something..."
         required={true}
+        role="combobox"
         style={Object {}}
         type="text"
         value="test"
@@ -226,7 +224,6 @@ exports[`Renders Autocomplete with Error without crashing 1`] = `
       <div
         className="suggestionsContainer"
         id="react-autowhatever-autocompletes"
-        role="listbox"
         style={Object {}}
       />
     </div>
@@ -248,6 +245,7 @@ exports[`Renders Autocomplete with Error without crashing 1`] = `
 exports[`Renders Autocomplete without crashing 1`] = `
 <div
   className="formGroup inline paddingTop"
+  id="autocomplete-container"
 >
   <span
     className="controlNote controlLabelRequired"
@@ -264,16 +262,13 @@ exports[`Renders Autocomplete without crashing 1`] = `
     className="autoCompleteContainer"
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="listbox"
-      aria-owns="react-autowhatever-autocompletes"
-      role="combobox"
       style={Object {}}
     >
       <input
         aria-activedescendant={null}
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-autocompletes"
+        aria-expanded={false}
+        aria-owns="react-autowhatever-autocompletes"
         autoComplete="off"
         autoFocus={false}
         className="formControl "
@@ -286,6 +281,7 @@ exports[`Renders Autocomplete without crashing 1`] = `
         onKeyDown={[Function]}
         placeholder="Type something..."
         required={true}
+        role="combobox"
         style={Object {}}
         type="text"
         value="test"
@@ -293,7 +289,6 @@ exports[`Renders Autocomplete without crashing 1`] = `
       <div
         className="suggestionsContainer"
         id="react-autowhatever-autocompletes"
-        role="listbox"
         style={Object {}}
       />
     </div>
@@ -361,6 +356,7 @@ exports[`Renders no suggestions container 1`] = `
 >
   <div
     className="formGroup inline paddingTop"
+    id="autocomplete-container"
   >
     <span
       className="controlNote controlLabelRequired"
@@ -496,17 +492,14 @@ exports[`Renders no suggestions container 1`] = `
           theme={Object {}}
         >
           <div
-            aria-expanded={true}
-            aria-haspopup="listbox"
-            aria-owns="react-autowhatever-autocompletes"
             key="react-autowhatever-autocompletes-container"
-            role="combobox"
             style={Object {}}
           >
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-controls="react-autowhatever-autocompletes"
+              aria-expanded={true}
+              aria-owns="react-autowhatever-autocompletes"
               autoComplete="off"
               autoFocus={false}
               className="formControl "
@@ -520,6 +513,7 @@ exports[`Renders no suggestions container 1`] = `
               onKeyDown={[Function]}
               placeholder="Type something..."
               required={true}
+              role="combobox"
               style={Object {}}
               type="text"
               value="z"
@@ -528,7 +522,6 @@ exports[`Renders no suggestions container 1`] = `
               className="suggestionsContainer"
               id="react-autowhatever-autocompletes"
               key="react-autowhatever-autocompletes-items-container"
-              role="listbox"
               style={Object {}}
             >
               <ItemsList
@@ -579,7 +572,6 @@ exports[`Renders no suggestions container 1`] = `
                   style={Object {}}
                 >
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={0}
                     id="react-autowhatever-autocompletes--item-0"
@@ -607,7 +599,6 @@ exports[`Renders no suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={0}
                       id="react-autowhatever-autocompletes--item-0"
@@ -632,7 +623,6 @@ exports[`Renders no suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={1}
                     id="react-autowhatever-autocompletes--item-1"
@@ -660,7 +650,6 @@ exports[`Renders no suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={1}
                       id="react-autowhatever-autocompletes--item-1"
@@ -685,7 +674,6 @@ exports[`Renders no suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={2}
                     id="react-autowhatever-autocompletes--item-2"
@@ -713,7 +701,6 @@ exports[`Renders no suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={2}
                       id="react-autowhatever-autocompletes--item-2"
@@ -738,7 +725,6 @@ exports[`Renders no suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={3}
                     id="react-autowhatever-autocompletes--item-3"
@@ -766,7 +752,6 @@ exports[`Renders no suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={3}
                       id="react-autowhatever-autocompletes--item-3"
@@ -791,7 +776,6 @@ exports[`Renders no suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={4}
                     id="react-autowhatever-autocompletes--item-4"
@@ -819,7 +803,6 @@ exports[`Renders no suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={4}
                       id="react-autowhatever-autocompletes--item-4"
@@ -844,7 +827,6 @@ exports[`Renders no suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={5}
                     id="react-autowhatever-autocompletes--item-5"
@@ -871,7 +853,6 @@ exports[`Renders no suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={5}
                       id="react-autowhatever-autocompletes--item-5"
@@ -958,6 +939,7 @@ exports[`Renders suggestions container 1`] = `
 >
   <div
     className="formGroup inline paddingTop"
+    id="autocomplete-container"
   >
     <span
       className="controlNote controlLabelRequired"
@@ -1093,17 +1075,14 @@ exports[`Renders suggestions container 1`] = `
           theme={Object {}}
         >
           <div
-            aria-expanded={true}
-            aria-haspopup="listbox"
-            aria-owns="react-autowhatever-autocompletes"
             key="react-autowhatever-autocompletes-container"
-            role="combobox"
             style={Object {}}
           >
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-controls="react-autowhatever-autocompletes"
+              aria-expanded={true}
+              aria-owns="react-autowhatever-autocompletes"
               autoComplete="off"
               autoFocus={false}
               className="formControl "
@@ -1117,6 +1096,7 @@ exports[`Renders suggestions container 1`] = `
               onKeyDown={[Function]}
               placeholder="Type something..."
               required={true}
+              role="combobox"
               style={Object {}}
               type="text"
               value="a"
@@ -1125,7 +1105,6 @@ exports[`Renders suggestions container 1`] = `
               className="suggestionsContainer"
               id="react-autowhatever-autocompletes"
               key="react-autowhatever-autocompletes-items-container"
-              role="listbox"
               style={Object {}}
             >
               <ItemsList
@@ -1176,7 +1155,6 @@ exports[`Renders suggestions container 1`] = `
                   style={Object {}}
                 >
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={0}
                     id="react-autowhatever-autocompletes--item-0"
@@ -1204,7 +1182,6 @@ exports[`Renders suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={0}
                       id="react-autowhatever-autocompletes--item-0"
@@ -1229,7 +1206,6 @@ exports[`Renders suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={1}
                     id="react-autowhatever-autocompletes--item-1"
@@ -1257,7 +1233,6 @@ exports[`Renders suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={1}
                       id="react-autowhatever-autocompletes--item-1"
@@ -1282,7 +1257,6 @@ exports[`Renders suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={2}
                     id="react-autowhatever-autocompletes--item-2"
@@ -1310,7 +1284,6 @@ exports[`Renders suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={2}
                       id="react-autowhatever-autocompletes--item-2"
@@ -1335,7 +1308,6 @@ exports[`Renders suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={3}
                     id="react-autowhatever-autocompletes--item-3"
@@ -1363,7 +1335,6 @@ exports[`Renders suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={3}
                       id="react-autowhatever-autocompletes--item-3"
@@ -1388,7 +1359,6 @@ exports[`Renders suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={4}
                     id="react-autowhatever-autocompletes--item-4"
@@ -1416,7 +1386,6 @@ exports[`Renders suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={4}
                       id="react-autowhatever-autocompletes--item-4"
@@ -1441,7 +1410,6 @@ exports[`Renders suggestions container 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={5}
                     id="react-autowhatever-autocompletes--item-5"
@@ -1468,7 +1436,6 @@ exports[`Renders suggestions container 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={5}
                       id="react-autowhatever-autocompletes--item-5"
@@ -1555,6 +1522,7 @@ exports[`Updates value on selection 1`] = `
 >
   <div
     className="formGroup inline paddingTop"
+    id="autocomplete-container"
   >
     <span
       className="controlNote controlLabelRequired"
@@ -1638,17 +1606,14 @@ exports[`Updates value on selection 1`] = `
           theme={Object {}}
         >
           <div
-            aria-expanded={false}
-            aria-haspopup="listbox"
-            aria-owns="react-autowhatever-autocompletes"
             key="react-autowhatever-autocompletes-container"
-            role="combobox"
             style={Object {}}
           >
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-controls="react-autowhatever-autocompletes"
+              aria-expanded={false}
+              aria-owns="react-autowhatever-autocompletes"
               autoComplete="off"
               autoFocus={false}
               className="formControl "
@@ -1662,6 +1627,7 @@ exports[`Updates value on selection 1`] = `
               onKeyDown={[Function]}
               placeholder="Type something..."
               required={true}
+              role="combobox"
               style={Object {}}
               type="text"
               value="apple"

--- a/tests/__snapshots__/Choice.test.jsx.snap
+++ b/tests/__snapshots__/Choice.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Renders Choice with a heading without crashing 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -93,6 +94,7 @@ exports[`Renders Choice with a heading without crashing 1`] = `
 exports[`Renders Choice with a label without crashing 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -183,6 +185,7 @@ exports[`Renders Choice with a label without crashing 1`] = `
 exports[`Renders Choice with radio buttons without crashing 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -268,6 +271,7 @@ exports[`Renders Choice with radio buttons without crashing 1`] = `
 exports[`Renders a Choice with a disabled option without crashing 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -377,6 +381,7 @@ exports[`Renders a Choice with a disabled option without crashing 1`] = `
 exports[`Renders a Choice with checked from route 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -462,6 +467,7 @@ exports[`Renders a Choice with checked from route 1`] = `
 exports[`Renders a Choice with custom style 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -547,6 +553,7 @@ exports[`Renders a Choice with custom style 1`] = `
 exports[`Renders a Choice with custom style disabled 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -632,6 +639,7 @@ exports[`Renders a Choice with custom style disabled 1`] = `
 exports[`Renders a Choice with default checked without crashing 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -717,6 +725,7 @@ exports[`Renders a Choice with default checked without crashing 1`] = `
 exports[`Renders a Choice with no default checked from route if it is not an option 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -802,6 +811,7 @@ exports[`Renders a Choice with no default checked from route if it is not an opt
 exports[`Renders a Choice with no default checked from route if it is the other name 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -887,6 +897,7 @@ exports[`Renders a Choice with no default checked from route if it is the other 
 exports[`Renders a Choice with no default checked if it's not an option 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -972,6 +983,7 @@ exports[`Renders a Choice with no default checked if it's not an option 1`] = `
 exports[`Renders a Choice with optionsPerRow set without crashing 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -1057,6 +1069,7 @@ exports[`Renders a Choice with optionsPerRow set without crashing 1`] = `
 exports[`Renders a disabled Choice without crashing 1`] = `
 <div
   className="formGroup"
+  id="test-container"
 >
   
   <div
@@ -1182,6 +1195,7 @@ exports[`Renders an error if errors prop is set 1`] = `
 >
   <div
     className="formGroup"
+    id="test-container"
   >
     <div
       className="radioContainer false"

--- a/tests/__snapshots__/Combobox.test.jsx.snap
+++ b/tests/__snapshots__/Combobox.test.jsx.snap
@@ -41,6 +41,7 @@ exports[`Causes dropdown to show when input is focused 1`] = `
 >
   <div
     className="formGroup inline "
+    id="name-container"
   >
     <label
       className="controlLabel false "
@@ -190,17 +191,14 @@ exports[`Causes dropdown to show when input is focused 1`] = `
           theme={Object {}}
         >
           <div
-            aria-expanded={true}
-            aria-haspopup="listbox"
-            aria-owns="react-autowhatever-1"
             key="react-autowhatever-1-container"
-            role="combobox"
             style={Object {}}
           >
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-controls="react-autowhatever-1"
+              aria-expanded={true}
+              aria-owns="react-autowhatever-1"
               autoComplete="off"
               className="formControl false "
               disabled={false}
@@ -213,6 +211,7 @@ exports[`Causes dropdown to show when input is focused 1`] = `
               onKeyDown={[Function]}
               placeholder="Type m"
               required={true}
+              role="combobox"
               style={Object {}}
               type="text"
               value=""
@@ -220,7 +219,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
             <div
               id="react-autowhatever-1"
               key="react-autowhatever-1-items-container"
-              role="listbox"
               style={Object {}}
             >
               <ItemsList
@@ -281,7 +279,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                   style={Object {}}
                 >
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={0}
                     id="react-autowhatever-1--item-0"
@@ -308,7 +305,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={0}
                       id="react-autowhatever-1--item-0"
@@ -326,7 +322,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={1}
                     id="react-autowhatever-1--item-1"
@@ -353,7 +348,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={1}
                       id="react-autowhatever-1--item-1"
@@ -371,7 +365,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={2}
                     id="react-autowhatever-1--item-2"
@@ -398,7 +391,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={2}
                       id="react-autowhatever-1--item-2"
@@ -416,7 +408,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={3}
                     id="react-autowhatever-1--item-3"
@@ -443,7 +434,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={3}
                       id="react-autowhatever-1--item-3"
@@ -461,7 +451,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={4}
                     id="react-autowhatever-1--item-4"
@@ -488,7 +477,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={4}
                       id="react-autowhatever-1--item-4"
@@ -506,7 +494,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={5}
                     id="react-autowhatever-1--item-5"
@@ -533,7 +520,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={5}
                       id="react-autowhatever-1--item-5"
@@ -551,7 +537,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={6}
                     id="react-autowhatever-1--item-6"
@@ -578,7 +563,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={6}
                       id="react-autowhatever-1--item-6"
@@ -596,7 +580,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={7}
                     id="react-autowhatever-1--item-7"
@@ -623,7 +606,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={7}
                       id="react-autowhatever-1--item-7"
@@ -641,7 +623,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={8}
                     id="react-autowhatever-1--item-8"
@@ -668,7 +649,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={8}
                       id="react-autowhatever-1--item-8"
@@ -686,7 +666,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={9}
                     id="react-autowhatever-1--item-9"
@@ -713,7 +692,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={9}
                       id="react-autowhatever-1--item-9"
@@ -731,7 +709,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     </li>
                   </Item>
                   <Item
-                    aria-selected={false}
                     data-section-index={null}
                     data-suggestion-index={10}
                     id="react-autowhatever-1--item-10"
@@ -758,7 +735,6 @@ exports[`Causes dropdown to show when input is focused 1`] = `
                     style={Object {}}
                   >
                     <li
-                      aria-selected={false}
                       data-section-index={null}
                       data-suggestion-index={10}
                       id="react-autowhatever-1--item-10"
@@ -789,6 +765,7 @@ exports[`Causes dropdown to show when input is focused 1`] = `
 exports[`Renders Combobox with an error message without crashing 1`] = `
 <div
   className="formGroup inline "
+  id="name-container"
 >
   
   <label
@@ -801,16 +778,13 @@ exports[`Renders Combobox with an error message without crashing 1`] = `
     className="container"
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="listbox"
-      aria-owns="react-autowhatever-1"
-      role="combobox"
       style={Object {}}
     >
       <input
         aria-activedescendant={null}
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
+        aria-expanded={false}
+        aria-owns="react-autowhatever-1"
         autoComplete="off"
         className="formControl false formControlError"
         disabled={false}
@@ -822,13 +796,13 @@ exports[`Renders Combobox with an error message without crashing 1`] = `
         onKeyDown={[Function]}
         placeholder="Type m"
         required={true}
+        role="combobox"
         style={Object {}}
         type="text"
         value=""
       />
       <div
         id="react-autowhatever-1"
-        role="listbox"
         style={Object {}}
       />
     </div>
@@ -850,6 +824,7 @@ exports[`Renders Combobox with an error message without crashing 1`] = `
 exports[`Renders Combobox without crashing 1`] = `
 <div
   className="formGroup inline "
+  id="name-container"
 >
   
   <label
@@ -862,16 +837,13 @@ exports[`Renders Combobox without crashing 1`] = `
     className="container"
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="listbox"
-      aria-owns="react-autowhatever-1"
-      role="combobox"
       style={Object {}}
     >
       <input
         aria-activedescendant={null}
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
+        aria-expanded={false}
+        aria-owns="react-autowhatever-1"
         autoComplete="off"
         className="formControl false "
         disabled={false}
@@ -883,13 +855,13 @@ exports[`Renders Combobox without crashing 1`] = `
         onKeyDown={[Function]}
         placeholder="Type m"
         required={true}
+        role="combobox"
         style={Object {}}
         type="text"
         value=""
       />
       <div
         id="react-autowhatever-1"
-        role="listbox"
         style={Object {}}
       />
     </div>
@@ -901,6 +873,7 @@ exports[`Renders Combobox without crashing 1`] = `
 exports[`Searchable Combobox Renders notSearchableCombobox without crashing 1`] = `
 <div
   className="formGroup inline "
+  id="name-container"
 >
   
   <label
@@ -913,16 +886,13 @@ exports[`Searchable Combobox Renders notSearchableCombobox without crashing 1`] 
     className="container"
   >
     <div
-      aria-expanded={false}
-      aria-haspopup="listbox"
-      aria-owns="react-autowhatever-1"
-      role="combobox"
       style={Object {}}
     >
       <input
         aria-activedescendant={null}
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
+        aria-expanded={false}
+        aria-owns="react-autowhatever-1"
         autoComplete="off"
         className="formControl isNotSearchable "
         disabled={false}
@@ -934,13 +904,13 @@ exports[`Searchable Combobox Renders notSearchableCombobox without crashing 1`] 
         onKeyDown={[Function]}
         placeholder="Type m"
         required={true}
+        role="combobox"
         style={Object {}}
         type="text"
         value=""
       />
       <div
         id="react-autowhatever-1"
-        role="listbox"
         style={Object {}}
       />
     </div>

--- a/tests/__snapshots__/DatePicker.test.jsx.snap
+++ b/tests/__snapshots__/DatePicker.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Renders datepicker with an error message without crashing 1`] = `
 <div
   className="formGroup inline datePickerContainer "
+  id="date-picker-container"
 >
   
   <label
@@ -43,6 +44,7 @@ exports[`Renders datepicker with an error message without crashing 1`] = `
 exports[`Renders datepicker without crashing 1`] = `
 <div
   className="formGroup inline datePickerContainer "
+  id="date-picker-container"
 >
   
   <label

--- a/tests/__snapshots__/Modal.test.jsx.snap
+++ b/tests/__snapshots__/Modal.test.jsx.snap
@@ -36,7 +36,11 @@ exports[`Renders Modal without crashing 1`] = `
     <FocusTrap
       _createFocusTrap={[Function]}
       active={true}
-      focusTrapOptions={Object {}}
+      focusTrapOptions={
+        Object {
+          "escapeDeactivates": true,
+        }
+      }
       paused={false}
       tag="div"
     >

--- a/tests/__snapshots__/MultipleChoice.test.jsx.snap
+++ b/tests/__snapshots__/MultipleChoice.test.jsx.snap
@@ -48,6 +48,7 @@ exports[`Change status of MultipleChoice on onChange with lots of options 1`] = 
 >
   <div
     className="formGroup formGroupMultipleChoice inline"
+    id="choice[]-container"
   >
     <Label
       classNames="inlineLabel"
@@ -213,6 +214,7 @@ exports[`Changes status on MultipleChoice onChange 1`] = `
 >
   <div
     className="formGroup formGroupMultipleChoice inline"
+    id="choice[]-container"
   >
     <Label
       classNames="inlineLabel"
@@ -261,6 +263,7 @@ exports[`Changes status on MultipleChoice onChange 1`] = `
 exports[`Renders MultipleChoice with inputStyle buttons without crashing 1`] = `
 <div
   className="formGroup formGroupMultipleChoice buttons"
+  id="choice[]-container"
 >
   
   <div
@@ -299,6 +302,7 @@ exports[`Renders MultipleChoice with inputStyle buttons without crashing 1`] = `
 exports[`Renders MultipleChoice without crashing 1`] = `
 <div
   className="formGroup formGroupMultipleChoice inline"
+  id="choice[]-container"
 >
   
   <div
@@ -337,6 +341,7 @@ exports[`Renders MultipleChoice without crashing 1`] = `
 exports[`Renders MultipleCoices without crashing 1`] = `
 <div
   className="formGroup formGroupMultipleChoice inline"
+  id="choice[]-container"
 >
   
   <div
@@ -465,6 +470,7 @@ exports[`Renders an error if errors prop is set 1`] = `
 >
   <div
     className="formGroup formGroupMultipleChoice buttons"
+    id="choice[]-container"
   >
     <Label
       classNames=""
@@ -528,6 +534,7 @@ exports[`Renders an error if errors prop is set 1`] = `
 exports[`Renders deprecated MultipleChoice without crashing 1`] = `
 <div
   className="formGroup formGroupMultipleChoice inline"
+  id="choice[]-container"
 >
   
   <div

--- a/tests/__snapshots__/Select.test.jsx.snap
+++ b/tests/__snapshots__/Select.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`Changes status on value change 1`] = `
 >
   <div
     className="formGroup inline"
+    id="select-container"
   >
     <Label
       classNames={Array []}
@@ -105,6 +106,7 @@ exports[`Changes status on value change 1`] = `
 exports[`Renders Select with an array of items 1`] = `
 <div
   className="formGroup inline"
+  id="select-container"
 >
   
   <label
@@ -167,6 +169,7 @@ exports[`Renders Select with an array of items 1`] = `
 exports[`Renders Select with an error message without crashing 1`] = `
 <div
   className="formGroup inline"
+  id="select-container"
 >
   
   <label
@@ -239,6 +242,7 @@ exports[`Renders Select with an error message without crashing 1`] = `
 exports[`Renders Select without crashing 1`] = `
 <div
   className="formGroup inline"
+  id="select-container"
 >
   
   <label
@@ -301,6 +305,7 @@ exports[`Renders Select without crashing 1`] = `
 exports[`Renders deprecated select without crashing 1`] = `
 <div
   className="formGroup inline"
+  id="select-container"
 >
   
   <label

--- a/tests/__snapshots__/Stars.test.jsx.snap
+++ b/tests/__snapshots__/Stars.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`Deselects stars 1`] = `
   >
     <div
       className="starsContainer false"
+      id="stars-container"
     >
       <div
         className="starsRow"
@@ -284,6 +285,7 @@ exports[`Deselects stars 1`] = `
   >
     <div
       className="starsContainer false"
+      id="stars2-container"
     >
       <div
         className="starsRow"
@@ -532,6 +534,7 @@ exports[`Deselects stars 1`] = `
 exports[`Renders correctly rounded star values 1`] = `
 <div
   className="starsContainer staticStars"
+  id="stars-container"
 >
   <div
     className="starsRow"
@@ -711,6 +714,7 @@ exports[`Renders correctly rounded star values 1`] = `
 exports[`Renders empty stars with no value 1`] = `
 <div
   className="starsContainer staticStars"
+  id="stars-container"
 >
   <div
     className="starsRow"
@@ -890,6 +894,7 @@ exports[`Renders empty stars with no value 1`] = `
 exports[`Renders selectable Stars without crashing 1`] = `
 <div
   className="starsContainer false"
+  id="stars-container"
 >
   <div
     className="starsRow"
@@ -1130,6 +1135,7 @@ exports[`Renders selectable Stars without crashing 1`] = `
 exports[`Renders static Stars without crashing 1`] = `
 <div
   className="starsContainer staticStars"
+  id="stars-container"
 >
   <div
     className="starsRow"

--- a/tests/__snapshots__/TextField.test.jsx.snap
+++ b/tests/__snapshots__/TextField.test.jsx.snap
@@ -69,6 +69,7 @@ exports[`Badwords should highlight correctly 1`] = `
 >
   <div
     className="formGroup inline"
+    id="text-field-container"
   >
     <InfoLabel
       displayLength={false}
@@ -216,6 +217,7 @@ exports[`Changes output on value change manipulation 1`] = `
 >
   <div
     className="formGroup inline paddingTop"
+    id="text-field-container"
   >
     <InfoLabel
       displayLength={false}
@@ -264,6 +266,7 @@ exports[`Changes output on value change manipulation 1`] = `
 exports[`Renders A TextField with visible character counter without crashing 1`] = `
 <div
   className="formGroup inline paddingTop"
+  id="text-field-container"
 >
   <span
     className="controlNote controlLabelRequired"
@@ -308,6 +311,7 @@ exports[`Renders A TextField with visible character counter without crashing 1`]
 exports[`Renders TextField with an error message without crashing 1`] = `
 <div
   className="formGroup inline paddingTop"
+  id="text-field-container"
 >
   <span
     className="controlNote controlLabelRequired"
@@ -358,6 +362,7 @@ exports[`Renders TextField with an error message without crashing 1`] = `
 exports[`Renders TextField with multiline without crashing 1`] = `
 <div
   className="formGroup inline paddingTop"
+  id="text-field-container"
 >
   <span
     className="controlNote controlLabelRequired"
@@ -397,6 +402,7 @@ exports[`Renders TextField with multiline without crashing 1`] = `
 exports[`Renders TextField without crashing 1`] = `
 <div
   className="formGroup inline paddingTop"
+  id="text-field-container"
 >
   <span
     className="controlNote controlLabelRequired"
@@ -437,6 +443,7 @@ exports[`Renders TextField without crashing 1`] = `
 exports[`Renders a TextField with a ToolTip without crashing 1`] = `
 <div
   className="formGroup inline"
+  id="text-field-container"
 >
   <span
     className="labelContainer"
@@ -501,6 +508,7 @@ exports[`Renders a TextField with a ToolTip without crashing 1`] = `
 exports[`Renders a medium size Textfield with multiline without crashing 1`] = `
 <div
   className="formGroup mediumSize"
+  id="text-field-container"
 >
   <label
     className="controlLabel controlLabelMediumSize"


### PR DESCRIPTION
It is difficult to test nukleus components since there are no unique identifiers for containers.
With this PR we are adding IDs to each container, so that we can create sections in our end-to-end tests for easier location of elements.