### PR TITLE
[KUNTECH-3561] Fix Paginator behavior

### DIFF
--- a/components/Paginator/index.jsx
+++ b/components/Paginator/index.jsx
@@ -43,6 +43,10 @@ export default class Paginator extends React.Component {
     return pageRange;
   }
 
+  parseQueryObject(query = {}) {
+    return (typeof query === 'object') ? query : queryString.parse(query);
+  }
+
   getNewProps (queryValue) {
     const {
       baseLink,
@@ -51,7 +55,7 @@ export default class Paginator extends React.Component {
       queryKey
     } = this.props;
 
-    const queryObject = (typeof query === 'object') ? query : queryString.parse(query);
+    const queryObject = this.parseQueryObject(query);
     const queryParams = queryString.stringify({...queryObject, [queryKey]: queryValue});
 
     if (baseLink.props.to) {
@@ -78,7 +82,7 @@ export default class Paginator extends React.Component {
       query
     } = this.props;
 
-    const queryObject = (typeof query === 'object') ? query : queryString.parse(query);
+    const queryObject = this.parseQueryObject(query);
 
     const currentPage = Number(queryObject[queryKey]) || 1;
     const totalPagesArray = this.getPageRange(currentPage);

--- a/components/Paginator/index.jsx
+++ b/components/Paginator/index.jsx
@@ -2,14 +2,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import queryString 'query-string';
+import queryString from 'query-string';
 
 import styles from './index.scss';
-
-import {
-  queryParamsToObject,
-  queryParamsToString
-} from '../../utils/params';
 
 export default class Paginator extends React.Component {
   static propTypes = {
@@ -56,8 +51,8 @@ export default class Paginator extends React.Component {
       queryKey
     } = this.props;
 
-    const queryObject = queryParamsToObject(query);
-    const queryParams = queryParamsToString({...queryObject, [queryKey]: queryValue});
+    const queryObject = (typeof query === 'object') ? query : queryString.parse(query);
+    const queryParams = queryString.stringify({...queryObject, [queryKey]: queryValue});
 
     if (baseLink.props.to) {
       return {
@@ -83,7 +78,8 @@ export default class Paginator extends React.Component {
       query
     } = this.props;
 
-    const queryObject = queryParamsToObject(query);
+    const queryObject = (typeof query === 'object') ? query : queryString.parse(query);
+
     const currentPage = Number(queryObject[queryKey]) || 1;
     const totalPagesArray = this.getPageRange(currentPage);
     const previousPage = currentPage !== 1 ? currentPage - 1 : currentPage;

--- a/components/Paginator/index.jsx
+++ b/components/Paginator/index.jsx
@@ -43,10 +43,6 @@ export default class Paginator extends React.Component {
     return pageRange;
   }
 
-  parseQueryObject(query = {}) {
-    return (typeof query === 'object') ? query : queryString.parse(query);
-  }
-
   getNewProps (queryValue) {
     const {
       baseLink,
@@ -73,6 +69,8 @@ export default class Paginator extends React.Component {
       [location]: `${pathname}?${queryParams}`
     };
   }
+
+  parseQueryObject = query => (typeof query === 'object') ? query : queryString.parse(query);
 
   render () {
     const {

--- a/components/Paginator/index.jsx
+++ b/components/Paginator/index.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import queryString 'query-string';
 
 import styles from './index.scss';
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "13.0.1",
+  "version": "13.0.2",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "debounce": "1.0.2",
     "moment": "2.22.2",
     "prop-types": "15.6.2",
+    "query-string": "^6.2.0",
     "react-aria-modal": "2.12.2",
     "react-autosuggest": "9.3.4",
     "react-datepicker": "1.4.1",


### PR DESCRIPTION
When query strings are result of a checkbox/multiple choice field, they will appear like `?choice[]=answer&choice[]=answer2`, however, Paginator is changing these fields when navigating between pages to `?choice[]=answer,answer2`, which leads to different results when backend isn't ready to deal with both ways.

This PR aims to improve how Paginator component deals with query strings, whether they come as strings or objects. `query-string` lib replaces our previous functions on utils related to query string processing.