### PR TITLE
[KUNTECH-3614] Update react-datepicker to keep compatibility with latest React version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "query-string": "6.2.0",
     "react-aria-modal": "2.12.2",
     "react-autosuggest": "9.3.4",
-    "react-datepicker": "1.7.0",
+    "react-datepicker": "1.8.0",
     "react-scroll": "1.7.9"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "query-string": "6.2.0",
     "react-aria-modal": "2.12.2",
     "react-autosuggest": "9.3.4",
-    "react-datepicker": "1.4.1",
+    "react-datepicker": "1.7.0",
     "react-scroll": "1.7.9"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "node_modules"
     ]
   },
-  "version": "13.0.5",
+  "version": "13.0.6",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {


### PR DESCRIPTION
I'm seeing errors when importing DatePicker component using React 16.5.2. This update intents to fix it.