### PR TITLE
go back postcss version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jest-junit": "6.0.1",
     "node-sass": "4.11.0",
     "node-sass-module-importer": "0.1.0",
-    "postcss-cli": "6.1.1",
+    "postcss-cli": "6.1.0",
     "postcss-loader": "3.0.0",
     "react": "16.7.0",
     "react-dom": "16.7.0",


### PR DESCRIPTION
Performing 'npm install' or 'npm run sass' returned an error message. It seems that a postcss dependency caused this (https://github.com/postcss/postcss-cli/issues/265).

I could fix it locally with ```npm update globby --depth 5```, but I think the best way is to go back a version for now.