### PR TITLE
fix disabled state for MS Edge

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -23,3 +23,10 @@ body {
   margin: 8px;
   background: white;
 }
+
+// bug workaround for MS Edge
+// MS Edge does not recalculate style for :disabled pseudo-class followed by sibling combinator
+// https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11295231/
+[disabled] ~ dummy {
+  width: auto;
+}

--- a/main.scss
+++ b/main.scss
@@ -27,6 +27,6 @@ body {
 // bug workaround for MS Edge
 // MS Edge does not recalculate style for :disabled pseudo-class followed by sibling combinator
 // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11295231/
-[disabled] ~ dummy {
+[disabled] ~ dummy { // NOSONAR
   width: auto;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nukleus",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {


### PR DESCRIPTION
I ran into a bug with MS Edge where the browser would not update the MulipleChoice component's styles when setting the input elements to `disabled`.

Took me a while to discover that this is a known issue with MS Edge (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11295231/). There's a simple workaround for it, which I put into `main.scss` to prevent this issue from happening anywhere else in nukleus. 