### PR TITLE
[BUG-FIX] Always update items in autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nukleus",
-  "version": "15.0.3",
+  "version": "15.0.4",
   "description": "Shared components repo for kununu projects",
   "main": "dist/components/index.js",
   "repository": {

--- a/src/components/Autocomplete/index.jsx
+++ b/src/components/Autocomplete/index.jsx
@@ -111,7 +111,6 @@ export default class Autocomplete extends React.Component {
 
   componentWillReceiveProps (nextProps) {
     const {
-      data,
       query,
       name,
     } = this.props;

--- a/src/components/Autocomplete/index.jsx
+++ b/src/components/Autocomplete/index.jsx
@@ -117,9 +117,7 @@ export default class Autocomplete extends React.Component {
     } = this.props;
     const queryObject = queryParamsToObject(query);
 
-    if (JSON.stringify(nextProps.data.items) !== JSON.stringify(data.items)) {
-      this.setState({suggestions: nextProps.data.items});
-    }
+    this.setState({suggestions: nextProps.data.items});
 
     if (nextProps.error) this.showError();
     if (!this.needsUpdate(nextProps)) return;


### PR DESCRIPTION
When an empty items is passed to the component it sets the suggestions state to an empty array and it should not display the suggestions container. However, this is sometimes not the case and the suggestions remain visible even when the items are empty which can lead to bugs.

This fix helps ensure that the suggestions are successfully hidden when there are empty items passed.